### PR TITLE
Fix invalid condition when incremental fetching enabled

### DIFF
--- a/src/Query/DefaultQueryFactory.php
+++ b/src/Query/DefaultQueryFactory.php
@@ -44,10 +44,16 @@ class DefaultQueryFactory implements QueryFactory
             );
         }
 
+        if ($exportConfig->isIncrementalFetching()) {
+            $sql[] = sprintf(
+                'ORDER BY %s',
+                $connection->quoteIdentifier($exportConfig->getIncrementalFetchingColumn()),
+            );
+        }
+
         if ($exportConfig->hasIncrementalFetchingLimit()) {
             $sql[] = sprintf(
-                'ORDER BY %s LIMIT %d',
-                $connection->quoteIdentifier($exportConfig->getIncrementalFetchingColumn()),
+                'LIMIT %d',
                 $exportConfig->getIncrementalFetchingLimit()
             );
         }

--- a/tests/phpunit/DefaultQueryFactoryTest.php
+++ b/tests/phpunit/DefaultQueryFactoryTest.php
@@ -39,14 +39,14 @@ class DefaultQueryFactoryTest extends BaseTest
                 ],
             ],
             'incrementalFetchingNoState' => [
-                'SELECT * FROM `bar`.`foo`',
+                'SELECT * FROM `bar`.`foo` ORDER BY `col2`',
                 [
                     'table' => ['tableName' => 'foo', 'schema' => 'bar'],
                     'incrementalFetchingColumn' => 'col2',
                 ],
             ],
             'incrementalFetchingNoStateColumns' => [
-                'SELECT `col1`, `col2` FROM `bar`.`foo`',
+                'SELECT `col1`, `col2` FROM `bar`.`foo` ORDER BY `col2`',
                 [
                     'table' => ['tableName' => 'foo', 'schema' => 'bar'],
                     'columns' => ['col1', 'col2'],
@@ -54,7 +54,7 @@ class DefaultQueryFactoryTest extends BaseTest
                 ],
             ],
             'incrementalFetchingState' => [
-                'SELECT * FROM `bar`.`foo` WHERE `col2` >= \'123\'',
+                'SELECT * FROM `bar`.`foo` WHERE `col2` >= \'123\' ORDER BY `col2`',
                 [
                     'table' => ['tableName' => 'foo', 'schema' => 'bar'],
                     'incrementalFetchingColumn' => 'col2',
@@ -64,7 +64,7 @@ class DefaultQueryFactoryTest extends BaseTest
                 ],
             ],
             'incrementalFetchingStateColumns' => [
-                'SELECT `col1`, `col2` FROM `bar`.`foo` WHERE `col2` >= \'123\'',
+                'SELECT `col1`, `col2` FROM `bar`.`foo` WHERE `col2` >= \'123\' ORDER BY `col2`',
                 [
                     'table' => ['tableName' => 'foo', 'schema' => 'bar'],
                     'columns' => ['col1', 'col2'],


### PR DESCRIPTION
Changes:
- Fixed condition in incremental fetching - `ORDER BY` was missing when limit was disabled.