### PR TITLE
Allow set connect retries to db connection

### DIFF
--- a/src/Connection/BaseDbConnection.php
+++ b/src/Connection/BaseDbConnection.php
@@ -22,6 +22,8 @@ abstract class BaseDbConnection implements DbConnection
 
     protected LoggerInterface $logger;
 
+    protected int $connectMaxRetries;
+
     /**
      * Returns low-level connection resource or object.
      * @return resource|object
@@ -40,9 +42,10 @@ abstract class BaseDbConnection implements DbConnection
 
     abstract protected function getExpectedExceptionClasses(): array;
 
-    public function __construct(LoggerInterface $logger)
+    public function __construct(LoggerInterface $logger, int $connectMaxRetries = self::CONNECT_DEFAULT_MAX_RETRIES)
     {
         $this->logger = $logger;
+        $this->connectMaxRetries = max($connectMaxRetries, 1);
         $this->connectWithRetry();
     }
 
@@ -103,7 +106,7 @@ abstract class BaseDbConnection implements DbConnection
     {
         try {
             $this
-                ->createRetryProxy(self::CONNECT_MAX_RETRIES)
+                ->createRetryProxy($this->connectMaxRetries)
                 ->call(function (): void {
                     $this->connect();
                 });

--- a/src/Connection/DbConnection.php
+++ b/src/Connection/DbConnection.php
@@ -8,7 +8,7 @@ use Keboola\DbExtractor\Adapter\ValueObject\QueryResult;
 
 interface DbConnection
 {
-    public const CONNECT_MAX_RETRIES = 3;
+    public const CONNECT_DEFAULT_MAX_RETRIES = 3;
 
     public const DEFAULT_MAX_RETRIES = 5;
 

--- a/src/ODBC/OdbcConnection.php
+++ b/src/ODBC/OdbcConnection.php
@@ -29,13 +29,14 @@ class OdbcConnection extends BaseDbConnection
         string $dsn,
         string $user,
         string $password,
-        ?callable $init = null
+        ?callable $init = null,
+        int $connectMaxRetries = self::CONNECT_DEFAULT_MAX_RETRIES
     ) {
         $this->dsn = $dsn;
         $this->user = $user;
         $this->password = $password;
         $this->init = $init;
-        parent::__construct($logger);
+        parent::__construct($logger, $connectMaxRetries);
     }
 
     protected function connect(): void

--- a/src/PDO/PdoConnection.php
+++ b/src/PDO/PdoConnection.php
@@ -33,7 +33,8 @@ class PdoConnection extends BaseDbConnection
         string $user,
         string $password,
         array $options,
-        ?callable $init = null
+        ?callable $init = null,
+        int $connectMaxRetries = self::CONNECT_DEFAULT_MAX_RETRIES
     ) {
         // Convert errors to PDOExceptions
         $options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
@@ -43,7 +44,7 @@ class PdoConnection extends BaseDbConnection
         $this->password = $password;
         $this->options = $options;
         $this->init = $init;
-        parent::__construct($logger);
+        parent::__construct($logger, $connectMaxRetries);
     }
 
     protected function connect(): void

--- a/tests/phpunit/PDO/PdoConnectionTest.php
+++ b/tests/phpunit/PDO/PdoConnectionTest.php
@@ -19,14 +19,15 @@ class PdoConnectionTest extends BaseTest
 
     public function testInvalidHost(): void
     {
+        $retries = 2;
         try {
-            $this->createPdoConnection('invalid');
+            $this->createPdoConnection('invalid', null, $retries);
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
             Assert::assertStringContainsString('Name or service not known', $e->getMessage());
         }
 
-        for ($attempt=1; $attempt < DbConnection::CONNECT_MAX_RETRIES; $attempt++) {
+        for ($attempt=1; $attempt < $retries; $attempt++) {
             Assert::assertTrue($this->logger->hasInfoThatContains("Retrying... [{$attempt}x]"));
         }
     }
@@ -35,16 +36,33 @@ class PdoConnectionTest extends BaseTest
     {
         // Disable error handler, ... tests that PDO throws exception in this situation
         set_error_handler(null);
+        $retries = 2;
         try {
-            $this->createPdoConnection('invalid');
+            $this->createPdoConnection('invalid', null, $retries);
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
             Assert::assertStringContainsString('Name or service not known', $e->getMessage());
         }
 
-        for ($attempt=1; $attempt < DbConnection::CONNECT_MAX_RETRIES; $attempt++) {
+        for ($attempt=1; $attempt < $retries; $attempt++) {
             Assert::assertTrue($this->logger->hasInfoThatContains("Retrying... [{$attempt}x]"));
         }
+    }
+
+
+    public function testDisableConnectRetries(): void
+    {
+        // Disable error handler, ... tests that PDO throws exception in this situation
+        set_error_handler(null);
+        try {
+            $this->createPdoConnection('invalid', null, 1);
+            Assert::fail('Exception expected.');
+        } catch (UserExceptionInterface $e) {
+            Assert::assertStringContainsString('Name or service not known', $e->getMessage());
+        }
+
+        // No retry in logs
+        Assert::assertFalse($this->logger->hasInfoThatContains('Retrying...'));
     }
 
 

--- a/tests/phpunit/Traits/OdbcCreateConnectionTrait.php
+++ b/tests/phpunit/Traits/OdbcCreateConnectionTrait.php
@@ -11,8 +11,11 @@ trait OdbcCreateConnectionTrait
 {
     protected TestLogger $logger;
 
-    protected function createOdbcConnection(?string $host = null, ?int $port = null): OdbcConnection
-    {
+    protected function createOdbcConnection(
+        ?string $host = null,
+        ?int $port = null,
+        int $connectRetries = OdbcConnection::CONNECT_DEFAULT_MAX_RETRIES
+    ): OdbcConnection {
         $dns = sprintf(
             'Driver={MariaDB ODBC Driver};SERVER=%s;PORT=%d;DATABASE=%s;',
             $host ?? getenv('DB_HOST'),
@@ -24,6 +27,8 @@ trait OdbcCreateConnectionTrait
             $dns,
             (string) getenv('DB_USER'),
             (string) getenv('DB_PASSWORD'),
+            null,
+            $connectRetries
         );
     }
 }

--- a/tests/phpunit/Traits/PdoCreateConnectionTrait.php
+++ b/tests/phpunit/Traits/PdoCreateConnectionTrait.php
@@ -11,8 +11,11 @@ trait PdoCreateConnectionTrait
 {
     protected TestLogger $logger;
 
-    protected function createPdoConnection(?string $host = null, ?int $port = null): PdoConnection
-    {
+    protected function createPdoConnection(
+        ?string $host = null,
+        ?int $port = null,
+        int $connectRetries = PdoConnection::CONNECT_DEFAULT_MAX_RETRIES
+    ): PdoConnection {
         $dns = sprintf(
             'mysql:host=%s;port=%s;dbname=%s;charset=utf8',
             $host ?? getenv('DB_HOST'),
@@ -25,6 +28,8 @@ trait PdoCreateConnectionTrait
             (string) getenv('DB_USER'),
             (string) getenv('DB_PASSWORD'),
             [],
+            null,
+            $connectRetries
         );
     }
 }


### PR DESCRIPTION
Changes:
- Connect retries can be set by connection constructor.
- It allows to disable connect retries in sync actions if an error ocurred -> so sync action returns error and not timeout.