### PR TITLE
Get query metadata from ExportAdapter

### DIFF
--- a/src/ResultWriter/DefaultResultWriter.php
+++ b/src/ResultWriter/DefaultResultWriter.php
@@ -78,7 +78,7 @@ class DefaultResultWriter implements ResultWriter
         $incFetchingColMaxValue = $this->lastRow ?
             $this->getIncrementalFetchingValueFromLastRow($exportConfig) :
             $this->getIncrementalFetchingValueFromState($exportConfig);
-        return new ExportResult($csvFilePath, $this->rowsCount, $incFetchingColMaxValue);
+        return new ExportResult($csvFilePath, $this->rowsCount, $result->getMetadata(), $incFetchingColMaxValue);
     }
 
     protected function writeRows(

--- a/src/ValueObject/ExportResult.php
+++ b/src/ValueObject/ExportResult.php
@@ -10,12 +10,19 @@ class ExportResult
 
     protected int $rowsCount;
 
+    protected QueryMetadata $queryMetadata;
+
     protected ?string $incFetchingColMaxValue;
 
-    public function __construct(string $csvPath, int $rowsCount, ?string $incFetchingColMaxValue)
-    {
+    public function __construct(
+        string $csvPath,
+        int $rowsCount,
+        QueryMetadata $queryMetadata,
+        ?string $incFetchingColMaxValue
+    ) {
         $this->csvPath = $csvPath;
         $this->rowsCount = $rowsCount;
+        $this->queryMetadata = $queryMetadata;
         $this->incFetchingColMaxValue = $incFetchingColMaxValue;
     }
 
@@ -27,6 +34,11 @@ class ExportResult
     public function getRowsCount(): int
     {
         return $this->rowsCount;
+    }
+
+    public function getQueryMetadata(): QueryMetadata
+    {
+        return $this->queryMetadata;
     }
 
     public function getIncFetchingColMaxValue(): ?string

--- a/tests/phpunit/Fixtures/PassingExportAdapter.php
+++ b/tests/phpunit/Fixtures/PassingExportAdapter.php
@@ -6,7 +6,9 @@ namespace Keboola\DbExtractor\Adapter\Tests\Fixtures;
 
 use Keboola\DbExtractor\Adapter\ExportAdapter;
 use Keboola\DbExtractor\Adapter\ValueObject\ExportResult;
+use Keboola\DbExtractor\Adapter\ValueObject\QueryMetadata;
 use Keboola\DbExtractorConfig\Configuration\ValueObject\ExportConfig;
+use PHPUnit\Framework\MockObject\Generator;
 
 class PassingExportAdapter implements ExportAdapter
 {
@@ -27,7 +29,10 @@ class PassingExportAdapter implements ExportAdapter
     public function export(ExportConfig $exportConfig, string $csvFilePath): ExportResult
     {
         $this->exportCallCount++;
-        return new ExportResult($csvFilePath, 0, null);
+        $mockGenerator = new Generator();
+        /** @var QueryMetadata $queryMetadata */
+        $queryMetadata = $mockGenerator->getMock(QueryMetadata::class);
+        return new ExportResult($csvFilePath, 0, $queryMetadata, null);
     }
 
     public function getExportCallCount(): int


### PR DESCRIPTION
Changes:
- Added method `ExportResults::getQueryMetadata`.