### PR TITLE
Add method ExportResult::hasCsvHeader

### DIFF
--- a/src/ResultWriter/DefaultResultWriter.php
+++ b/src/ResultWriter/DefaultResultWriter.php
@@ -78,7 +78,19 @@ class DefaultResultWriter implements ResultWriter
         $incFetchingColMaxValue = $this->lastRow ?
             $this->getIncrementalFetchingValueFromLastRow($exportConfig) :
             $this->getIncrementalFetchingValueFromState($exportConfig);
-        return new ExportResult($csvFilePath, $this->rowsCount, $result->getMetadata(), $incFetchingColMaxValue);
+        return new ExportResult(
+            $csvFilePath,
+            $this->rowsCount,
+            $result->getMetadata(),
+            $this->hasCsvHeader($exportConfig),
+            $incFetchingColMaxValue
+        );
+    }
+
+    protected function hasCsvHeader(ExportConfig $exportConfig): bool
+    {
+        // If header is present in the CSV file, there are no columns metadata in the manifest.
+        return $exportConfig->hasQuery();
     }
 
     protected function writeRows(
@@ -87,11 +99,8 @@ class DefaultResultWriter implements ResultWriter
         ExportConfig $exportConfig,
         CsvWriter $csvWriter
     ): void {
-        // With custom query are no metadata in manifest, so header must be present
-        $includeHeader = $exportConfig->hasQuery();
-
         // Write header
-        if ($includeHeader) {
+        if ($this->hasCsvHeader($exportConfig)) {
             $this->writeHeader($queryMetadata->getColumns()->getNames(), $csvWriter);
         }
 

--- a/src/ValueObject/ExportResult.php
+++ b/src/ValueObject/ExportResult.php
@@ -12,17 +12,21 @@ class ExportResult
 
     protected QueryMetadata $queryMetadata;
 
+    protected bool $csvHeaderPresent;
+
     protected ?string $incFetchingColMaxValue;
 
     public function __construct(
         string $csvPath,
         int $rowsCount,
         QueryMetadata $queryMetadata,
+        bool $csvHeaderPresent,
         ?string $incFetchingColMaxValue
     ) {
         $this->csvPath = $csvPath;
         $this->rowsCount = $rowsCount;
         $this->queryMetadata = $queryMetadata;
+        $this->csvHeaderPresent = $csvHeaderPresent;
         $this->incFetchingColMaxValue = $incFetchingColMaxValue;
     }
 
@@ -39,6 +43,11 @@ class ExportResult
     public function getQueryMetadata(): QueryMetadata
     {
         return $this->queryMetadata;
+    }
+
+    public function hasCsvHeader(): bool
+    {
+        return $this->csvHeaderPresent;
     }
 
     public function getIncFetchingColMaxValue(): ?string

--- a/tests/phpunit/Fixtures/PassingExportAdapter.php
+++ b/tests/phpunit/Fixtures/PassingExportAdapter.php
@@ -32,7 +32,7 @@ class PassingExportAdapter implements ExportAdapter
         $mockGenerator = new Generator();
         /** @var QueryMetadata $queryMetadata */
         $queryMetadata = $mockGenerator->getMock(QueryMetadata::class);
-        return new ExportResult($csvFilePath, 0, $queryMetadata, null);
+        return new ExportResult($csvFilePath, 0, $queryMetadata, false, null);
     }
 
     public function getExportCallCount(): int


### PR DESCRIPTION
Changes:
- Added method `ExportResult::hasCsvHeader`.

Tak je potrebna este jedna zmena:
- Pri PDO/ODBC 
  - Ak je custom query, tak CSV ma hlavicku ... inak nema.
  - Pri MsSQL BCP, pripadne inych vlastnych adapteroch ... nema CSV hlavicku nikdy.
  - Preto musi byt v `ExportResult` tato informacia ... aby `BaseExtractor::createManifest` vedel, ci maju byt stlpce sucastou manifestu, alebo nie.
  - Tento PR robi tuto informaciu dostupnou, nemeni spravanie sa kodu.