### PR TITLE
ignore closeCursor PDOException

### DIFF
--- a/src/PDO/PdoQueryResult.php
+++ b/src/PDO/PdoQueryResult.php
@@ -7,6 +7,7 @@ namespace Keboola\DbExtractor\Adapter\PDO;
 use Iterator;
 use Keboola\DbExtractor\Adapter\ValueObject\QueryMetadata;
 use PDO;
+use PDOException;
 use PDOStatement;
 use Keboola\DbExtractor\Adapter\ValueObject\QueryResult;
 
@@ -74,7 +75,9 @@ class PdoQueryResult implements QueryResult
     public function closeCursor(): void
     {
         if ($this->closed === false) {
-            $this->stmt->closeCursor();
+            try {
+                $this->stmt->closeCursor();
+            } catch (PDOException $e) {}
             $this->closed = true;
         }
     }

--- a/src/PDO/PdoQueryResult.php
+++ b/src/PDO/PdoQueryResult.php
@@ -77,7 +77,8 @@ class PdoQueryResult implements QueryResult
         if ($this->closed === false) {
             try {
                 $this->stmt->closeCursor();
-            } catch (PDOException $e) {}
+            } catch (PDOException $e) {
+            }
             $this->closed = true;
         }
     }


### PR DESCRIPTION
u mssql hazí closeCursor Exceptionu při chybný query, která nedává smysl