### PR TITLE
[AJDA-892] Update base image from Debian Buster to Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli-buster
+FROM php:8.2-cli-trixie
 
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
@@ -10,10 +10,6 @@ WORKDIR /code/
 COPY docker/php-prod.ini /usr/local/etc/php/php.ini
 COPY docker/composer-install.sh /tmp/composer-install.sh
 COPY docker/MariaDB_odbc_driver_template.ini /etc/MariaDB_odbc_driver_template.ini
-
-# MariaDB ODBC driver package is in backports
-RUN printf "deb http://archive.debian.org/debian buster-backports main non-free" \
-    > /etc/apt/sources.list.d/backports.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ssh \

--- a/src/ODBC/OdbcNativeMetadataProvider.php
+++ b/src/ODBC/OdbcNativeMetadataProvider.php
@@ -205,13 +205,15 @@ class OdbcNativeMetadataProvider implements MetadataProvider
                     // % means ALL, see odbc_columns docs
                     $whitelistedTable ? $whitelistedTable->getName() : '%',
                 );
-                while ($pk = odbc_fetch_array($result)) {
-                    if ($this->isTableIgnored($pk)) {
-                        continue;
+                if ($result !== false) {
+                    while ($pk = odbc_fetch_array($result)) {
+                        if ($this->isTableIgnored($pk)) {
+                            continue;
+                        }
+                        $pks[$this->getColumnId($pk)] = $pk;
                     }
-                    $pks[$this->getColumnId($pk)] = $pk;
+                    odbc_free_result($result);
                 }
-                odbc_free_result($result);
             } catch (ErrorException $e) {
                 // some db vendors (like Hive) do not support primary keys
                 if (!str_contains($e->getMessage(), 'NullPointerException')) {

--- a/src/ODBC/OdbcNativeMetadataProvider.php
+++ b/src/ODBC/OdbcNativeMetadataProvider.php
@@ -170,16 +170,33 @@ class OdbcNativeMetadataProvider implements MetadataProvider
 
     /**
      * @param array|InputTable[] $whitelist
-     * @return array[string][]
+     * @return array<string, array<string, string>>
      * @throws ErrorException
      */
     protected function queryPrimaryKeys(array $whitelist): array
+    {
+        $pks = $this->queryPrimaryKeysOdbc($whitelist);
+
+        // Some ODBC drivers (eg. MariaDB 3.1.15 on Debian Trixie) don't support odbc_primarykeys,
+        // fall back to INFORMATION_SCHEMA which is SQL standard.
+        if (empty($pks)) {
+            $pks = $this->queryPrimaryKeysFallback($whitelist);
+        }
+
+        return $pks;
+    }
+
+    /**
+     * @param array|InputTable[] $whitelist
+     * @return array<string, array<string, string>>
+     * @throws ErrorException
+     */
+    protected function queryPrimaryKeysOdbc(array $whitelist): array
     {
         $whitelist = empty($whitelist) ? [null] : $whitelist;
         $pks = [];
 
         foreach ($whitelist as $whitelistedTable) {
-            $result = null;
             try {
                 $result = odbc_primarykeys(
                     $this->connection->getConnection(),
@@ -200,6 +217,67 @@ class OdbcNativeMetadataProvider implements MetadataProvider
                 if (!str_contains($e->getMessage(), 'NullPointerException')) {
                     throw $e;
                 }
+            }
+        }
+
+        return $pks;
+    }
+
+    /**
+     * Fallback for primary key detection using INFORMATION_SCHEMA (SQL standard).
+     * Used when odbc_primarykeys() returns empty results (eg. MariaDB ODBC 3.1.15).
+     * @param array|InputTable[] $whitelist
+     * @return array<string, array<string, string>>
+     */
+    protected function queryPrimaryKeysFallback(array $whitelist): array
+    {
+        $whitelist = empty($whitelist) ? [null] : $whitelist;
+        $pks = [];
+
+        foreach ($whitelist as $whitelistedTable) {
+            $tableName = $whitelistedTable ? $whitelistedTable->getName() : '%';
+
+            $conditions = ["tc.CONSTRAINT_TYPE = 'PRIMARY KEY'"];
+            if ($this->onlyFromCatalog !== null) {
+                $conditions[] = sprintf(
+                    'kcu.TABLE_SCHEMA = %s',
+                    $this->connection->quote($this->onlyFromCatalog),
+                );
+            }
+            if ($tableName !== '%') {
+                $conditions[] = sprintf(
+                    'kcu.TABLE_NAME = %s',
+                    $this->connection->quote($tableName),
+                );
+            }
+
+            $query = sprintf(
+                'SELECT kcu.TABLE_SCHEMA AS TABLE_CAT, ' .
+                "'' AS TABLE_SCHEM, " .
+                'kcu.TABLE_NAME, ' .
+                'kcu.COLUMN_NAME ' .
+                'FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE kcu ' .
+                'JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc ' .
+                'ON kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME ' .
+                'AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA ' .
+                'AND kcu.TABLE_NAME = tc.TABLE_NAME ' .
+                'WHERE %s',
+                implode(' AND ', $conditions),
+            );
+
+            try {
+                $result = odbc_exec($this->connection->getConnection(), $query);
+                if ($result !== false) {
+                    while ($pk = odbc_fetch_array($result)) {
+                        if ($this->isTableIgnored($pk)) {
+                            continue;
+                        }
+                        $pks[$this->getColumnId($pk)] = $pk;
+                    }
+                    odbc_free_result($result);
+                }
+            } catch (ErrorException $e) {
+                // INFORMATION_SCHEMA may not be available on all databases
             }
         }
 

--- a/tests/phpunit/AbstractExportAdapterTest.php
+++ b/tests/phpunit/AbstractExportAdapterTest.php
@@ -98,7 +98,7 @@ END;
             Assert::assertSame($e->getTryCount(), $retries);
             Assert::assertThat($e->getMessage(), Assert::logicalOr(
                 // Msg differs between PDO and ODBC
-                new StringContains('Lost connection to MySQL server'),
+                new StringContains('Lost connection to server'),
                 new StringContains('MySQL server has gone away'),
             ));
         }

--- a/tests/phpunit/ODBC/OdbcConnectionTest.php
+++ b/tests/phpunit/ODBC/OdbcConnectionTest.php
@@ -26,7 +26,7 @@ class OdbcConnectionTest extends BaseTest
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
             Assert::assertStringContainsString('Error connecting to DB: ', $e->getMessage());
-            Assert::assertStringContainsString('Unknown MySQL server host \'invalid\'', $e->getMessage());
+            Assert::assertStringContainsString('Unknown server host \'invalid\'', $e->getMessage());
         }
 
         for ($attempt=1; $attempt < $retries; $attempt++) {
@@ -44,7 +44,7 @@ class OdbcConnectionTest extends BaseTest
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
             Assert::assertStringContainsString('Error connecting to DB: ', $e->getMessage());
-            Assert::assertStringContainsString('Unknown MySQL server host \'invalid\'', $e->getMessage());
+            Assert::assertStringContainsString('Unknown server host \'invalid\'', $e->getMessage());
         }
 
         for ($attempt=1; $attempt < $retries; $attempt++) {
@@ -61,7 +61,7 @@ class OdbcConnectionTest extends BaseTest
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
             Assert::assertStringContainsString('Error connecting to DB: ', $e->getMessage());
-            Assert::assertStringContainsString('Unknown MySQL server host \'invalid\'', $e->getMessage());
+            Assert::assertStringContainsString('Unknown server host \'invalid\'', $e->getMessage());
         }
 
         // No retry in logs
@@ -87,7 +87,7 @@ class OdbcConnectionTest extends BaseTest
             $connection->testConnection();
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
         }
     }
 
@@ -116,7 +116,7 @@ class OdbcConnectionTest extends BaseTest
             $connection->testConnection();
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
             $this->closeSshTunnels();
         }
     }
@@ -133,7 +133,7 @@ class OdbcConnectionTest extends BaseTest
             $connection->testConnection();
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
         }
     }
 
@@ -173,7 +173,7 @@ class OdbcConnectionTest extends BaseTest
             Assert::fail('Exception expected.');
         } catch (DeadConnectionException $e) {
             Assert::assertStringContainsString('Dead connection:', $e->getMessage());
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
         }
     }
 
@@ -198,7 +198,7 @@ class OdbcConnectionTest extends BaseTest
             $connection->query('SELECT 123 as X, 456 as Y', $retries);
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
         }
 
         for ($attempt=1; $attempt < $retries; $attempt++) {
@@ -233,7 +233,7 @@ class OdbcConnectionTest extends BaseTest
             $connection->query('SELECT 123 as X, 456 as Y', $retries);
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
             $this->closeSshTunnels();
         }
     }
@@ -266,7 +266,7 @@ class OdbcConnectionTest extends BaseTest
             });
             Assert::fail('Exception expected.');
         } catch (UserExceptionInterface $e) {
-            Assert::assertStringContainsString('Lost connection to MySQL server', $e->getMessage());
+            Assert::assertStringContainsString('Lost connection to server', $e->getMessage());
         }
 
         for ($attempt=1; $attempt < $retries; $attempt++) {

--- a/tests/phpunit/ODBC/OdbcNativeMetadataProviderTest.php
+++ b/tests/phpunit/ODBC/OdbcNativeMetadataProviderTest.php
@@ -214,4 +214,32 @@ class OdbcNativeMetadataProviderTest extends BaseTest
         $this->metadataProvider = new OdbcNativeMetadataProvider($this->createOdbcConnection(), 'abc');
         Assert::assertCount(0, $this->metadataProvider->listTables()->getAll());
     }
+
+    public function testPrimaryKeysFallback(): void
+    {
+        // Use a subclass that forces ODBC PK query to return empty,
+        // so the INFORMATION_SCHEMA fallback is used.
+        $this->metadataProvider = new class (
+            $this->createOdbcConnection(),
+            $this->getDatabase(),
+        ) extends OdbcNativeMetadataProvider {
+            protected function queryPrimaryKeysOdbc(array $whitelist): array
+            {
+                return [];
+            }
+        };
+
+        $tables = $this->metadataProvider->listTables()->getAll();
+        $productsCols = $tables[0]->getColumns()->getAll();
+        $townsCols = $tables[2]->getColumns()->getAll();
+
+        // Primary keys should still be detected via INFORMATION_SCHEMA fallback
+        Assert::assertSame('id', $productsCols[0]->getName());
+        Assert::assertSame(true, $productsCols[0]->isPrimaryKey());
+        Assert::assertSame(false, $productsCols[1]->isPrimaryKey());
+
+        Assert::assertSame('id', $townsCols[0]->getName());
+        Assert::assertSame(true, $townsCols[0]->isPrimaryKey());
+        Assert::assertSame(false, $townsCols[1]->isPrimaryKey());
+    }
 }


### PR DESCRIPTION
## Summary
- Update Dockerfile base image from `php:8.2-cli-buster` to `php:8.2-cli-trixie`
- Remove buster-backports repository config (odbc-mariadb is now in Trixie main repo)
- Add INFORMATION_SCHEMA fallback for primary key detection (`odbc_primarykeys` is broken in MariaDB ODBC 3.1.15 shipped with Trixie)
- Update ODBC test assertions for new driver error messages

## Test plan
- [x] `composer ci` passes (phpcs, phpstan, 191 tests)
- [x] CI pipeline green

Resolves: https://linear.app/keboola/issue/AJDA-892